### PR TITLE
Require backports

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,7 @@ source:
   sha256: {{ sha256 }}
 
 build:
-  number: 0
+  number: 1
   skip: true  # [win]
   script: python setup.py install
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -20,10 +20,12 @@ requirements:
   build:
     - toolchain
     - python
+    - backports
     - xz 5.2.*
 
   run:
     - python
+    - backports
     - xz 5.2.*
 
 test:


### PR DESCRIPTION
Pulls in the `backports` package, which ensures the `backports` namespace is available in advance.