### PR TITLE
Refresh PR 25 patch

### DIFF
--- a/recipe/PR_25.patch
+++ b/recipe/PR_25.patch
@@ -1,24 +1,3 @@
-From b4248b04ccb57e8eec064e217f296e076deb1c6d Mon Sep 17 00:00:00 2001
-From: Nehal J Wani <nehaljw.kkd1@gmail.com>
-Date: Sun, 24 Dec 2017 01:11:31 +0530
-Subject: [PATCH 1/7] Add build folder to ignore list
-
----
- .gitignore | 3 +++
- 1 file changed, 3 insertions(+)
-
-diff --git .gitignore .gitignore
-index f45f7bf..f60cf8e 100644
---- .gitignore
-+++ .gitignore
-@@ -20,3 +20,6 @@
- *.pyo
- *.py{}
- *.py-e
-+
-+#Ignore the build folder created by distuils
-+build
-
 From 0c3f4c3eab69f10dd85af448fe4a70b26333f39a Mon Sep 17 00:00:00 2001
 From: Nehal J Wani <nehaljw.kkd1@gmail.com>
 Date: Sun, 24 Dec 2017 01:12:25 +0530

--- a/recipe/PR_25.patch
+++ b/recipe/PR_25.patch
@@ -1,7 +1,72 @@
+From b4248b04ccb57e8eec064e217f296e076deb1c6d Mon Sep 17 00:00:00 2001
+From: Nehal J Wani <nehaljw.kkd1@gmail.com>
+Date: Sun, 24 Dec 2017 01:11:31 +0530
+Subject: [PATCH 1/7] Add build folder to ignore list
+
+---
+ .gitignore | 3 +++
+ 1 file changed, 3 insertions(+)
+
+diff --git .gitignore .gitignore
+index f45f7bf..f60cf8e 100644
+--- .gitignore
++++ .gitignore
+@@ -20,3 +20,6 @@
+ *.pyo
+ *.py{}
+ *.py-e
++
++#Ignore the build folder created by distuils
++build
+
+From 0c3f4c3eab69f10dd85af448fe4a70b26333f39a Mon Sep 17 00:00:00 2001
+From: Nehal J Wani <nehaljw.kkd1@gmail.com>
+Date: Sun, 24 Dec 2017 01:12:25 +0530
+Subject: [PATCH 2/7] Add another fallback for test.support import
+
+From python 2.7.14 changelog:
+    - bpo-30207: To simplify backports from Python 3, the test.test_support
+      module was converted into a package and renamed to test.support.  The
+      test.script_helper module was moved into the test.support package.
+      Names test.test_support and test.script_helper are left as aliases to
+      test.support and test.support.script_helper.
+
+So, basically, python 2.7.14 fails with:
+Traceback (most recent call last):
+  File "<stdin>", line 1, in <module>
+  File "/usr/lib64/python2.7/test/test_support.py", line 2, in <module>
+    import test.support
+ImportError: No module named support
+
+This patch adds a fall back to import from backports.test.testsupport
+---
+ test/test_lzma.py | 8 ++++++--
+ 1 file changed, 6 insertions(+), 2 deletions(-)
+
+diff --git test/test_lzma.py test/test_lzma.py
+index 34264aa..173c9c1 100644
+--- test/test_lzma.py
++++ test/test_lzma.py
+@@ -8,8 +8,12 @@
+     # Try the location used on Python 3 first,
+     from test.support import _4G, TESTFN, import_module, bigmemtest, run_unittest, unlink
+ except ImportError:
+-    # Must be under Python 2 then,
+-    from test.test_support import _4G, TESTFN, import_module, bigmemtest, run_unittest, unlink
++    try:
++        # May be < Python 2.7.14
++        from test.test_support import _4G, TESTFN, import_module, bigmemtest, run_unittest, unlink
++    except ImportError:
++        # May be >=Python 2.7.14, <3
++        from future.backports.test.support import _4G, TESTFN, import_module, bigmemtest, run_unittest, unlink
+ 
+ import inspect
+ if "size" not in inspect.getargspec(bigmemtest).args:
+
 From b808eb63b3e4187d8aa689ad36f6e3fc4dad15ef Mon Sep 17 00:00:00 2001
 From: Nehal J Wani <nehaljw.kkd1@gmail.com>
 Date: Sun, 24 Dec 2017 01:16:08 +0530
-Subject: [PATCH 3/6] Fix 'name' of extension
+Subject: [PATCH 3/7] Fix 'name' of extension
 
 According to the documentation of distutils, 'name' is:
     the full name of the extension, including any packages - ie. not a
@@ -32,7 +97,7 @@ index 55c6847..477b9f4 100644
 From 826436a1e0c29d78f19af27760fd004cdf81ebc8 Mon Sep 17 00:00:00 2001
 From: Nehal J Wani <nehaljw.kkd1@gmail.com>
 Date: Sun, 24 Dec 2017 01:35:12 +0530
-Subject: [PATCH 4/6] Compute name of lzma library
+Subject: [PATCH 4/7] Compute name of lzma library
 
 For *nix-y builds (including mingw-64), -lzma would suffize. But for
 Visual Studio builds, the complete name for the .lib file is required.
@@ -64,7 +129,7 @@ index 477b9f4..1058510 100644
 From 4d3cba962f4e87da0db373a891195603e9a96875 Mon Sep 17 00:00:00 2001
 From: Nehal J Wani <nehaljw.kkd1@gmail.com>
 Date: Sun, 24 Dec 2017 03:39:10 +0530
-Subject: [PATCH 5/6] Add compiler flag to realign stack for 32bit gcc
+Subject: [PATCH 5/7] Add compiler flag to realign stack for 32bit gcc
 
 ---
  setup.py | 10 +++++++++-
@@ -97,3 +162,141 @@ index 1058510..31d18ae 100644
 +        'build_ext': build_ext_subclass,
      },
  )
+
+From ec168f9b47041d22744ba8a25b2fc1662b061fb0 Mon Sep 17 00:00:00 2001
+From: Nehal J Wani <nehaljw.kkd1@gmail.com>
+Date: Sun, 24 Dec 2017 01:38:25 +0530
+Subject: [PATCH 6/7] Add appveyor file for testing Windows builds
+
+---
+ .appveyor.yml | 74 +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+ 1 file changed, 74 insertions(+)
+ create mode 100644 .appveyor.yml
+
+diff --git .appveyor.yml .appveyor.yml
+new file mode 100644
+index 0000000..ce646c2
+--- /dev/null
++++ .appveyor.yml
+@@ -0,0 +1,74 @@
++clone_folder: C:\projects\backports.lzma
++
++shallow_clone: true
++
++environment:
++  matrix:
++
++    # We don't have a vs2008 build of xz on Windows, so we skip that for py27
++    - PYTHON_VERSION: "2.7"
++      PYTHON_ARCH: "64"
++      DISTUTILS_COMPILER: "mingw32"
++
++    - PYTHON_VERSION: "2.7"
++      PYTHON_ARCH: "32"
++      DISTUTILS_COMPILER: "mingw32"
++
++    # We have a vs2015 build of xz on Windows, so we test against that for py36
++    - PYTHON_VERSION: "3.6"
++      PYTHON_ARCH: "64"
++      DISTUTILS_COMPILER: "msvc"
++
++    - PYTHON_VERSION: "3.6"
++      PYTHON_ARCH: "32"
++      DISTUTILS_COMPILER: "msvc"
++
++    - PYTHON_VERSION: "3.6"
++      PYTHON_ARCH: "64"
++      DISTUTILS_COMPILER: "mingw32"
++
++    - PYTHON_VERSION: "3.6"
++      PYTHON_ARCH: "32"
++      DISTUTILS_COMPILER: "mingw32"
++
++init:
++  - ECHO %PYTHON_VERSION% %PYTHON_ARCH% %HOME%
++
++build_script:
++  # If there is a newer build queued for the same PR, cancel this one.
++  # The AppVeyor 'rollout builds' option is supposed to serve the same
++  # purpose but it is problematic because it tends to cancel builds pushed
++  # directly to master instead of just PR builds (or the converse).
++  # credits: JuliaLang developers.
++  - ps: if ($env:APPVEYOR_PULL_REQUEST_NUMBER -and $env:APPVEYOR_BUILD_NUMBER -ne ((Invoke-RestMethod `
++      https://ci.appveyor.com/api/projects/$env:APPVEYOR_ACCOUNT_NAME/$env:APPVEYOR_PROJECT_SLUG/history?recordsNumber=50).builds | `
++      Where-Object pullRequestId -eq $env:APPVEYOR_PULL_REQUEST_NUMBER)[0].buildNumber) { `
++        throw "There are newer queued builds for this pull request, failing early." }
++
++  # Need this for correct path to Miniconda setup
++  - if "%PYTHON_VERSION%" == "3.6" set BASE_PYTHON_VERSION=36
++  - if "%PYTHON_ARCH%" == "64" set ARCH_LABEL=-x64
++  - C:\Miniconda%BASE_PYTHON_VERSION%%ARCH_LABEL%\Scripts\activate
++
++  # Now that we have conda in path, let's go to the project directory
++  - cd /d C:\projects\backports.lzma
++
++  # In case I forget -y to any conda commands
++  - conda config --system --set always_yes true
++
++  # This is where the Visual Studio build of liblzma.lib will go
++  - set LIBRARY_PREFIX=%CONDA_PREFIX%\Library
++
++  # This is where the mingw-64 build of liblzma.lib will go
++  - if "%DISTUTILS_COMPILER%" == "mingw32" set LIBRARY_PREFIX=%LIBRARY_PREFIX%\mingw-w64
++
++  # Let's install the toolchain and the package that will provide liblzma
++  - if "%DISTUTILS_COMPILER%" == "mingw32" conda install -y libpython m2w64-toolchain m2w64-xz
++  - if "%DISTUTILS_COMPILER%" == "msvc" conda install -y xz
++  - python setup.py build_ext --include-dirs %LIBRARY_PREFIX%\include --library-dirs %LIBRARY_PREFIX%\lib -c%DISTUTILS_COMPILER%
++  - python setup.py install
++  - python setup.py clean --all
++
++  # Let's put this to test
++  - if "%PYTHON_VERSION%" == "2.7" conda install future
++  - python test\test_lzma.py
+
+From 37976356226e3ec5f925bc13461e2098fd2f1dfb Mon Sep 17 00:00:00 2001
+From: Nehal J Wani <nehaljw.kkd1@gmail.com>
+Date: Mon, 25 Dec 2017 13:05:13 +0530
+Subject: [PATCH 7/7] MinGW: Passing -DMS_WIN32 or -DMS_WIN64 is a must
+
+Do not rely on a patched distutils, pass these flags explicitly.
+
+xref: https://stackoverflow.com/a/19867426
+---
+ setup.py | 19 +++++++++++++++----
+ 1 file changed, 15 insertions(+), 4 deletions(-)
+
+diff --git setup.py setup.py
+index 31d18ae..b294786 100644
+--- setup.py
++++ setup.py
+@@ -29,14 +29,25 @@
+ 
+ lzmalib = '%slzma'%('lib' if sys.platform == 'win32' else '')
+ 
++is32bit = tuple.__itemsize__ == 4
++
++
+ class build_ext_subclass(build_ext):
+     def build_extensions(self):
+-        c = self.compiler.compiler_type
+-        if c == "mingw32" and sys.maxsize <= 2**32:
+-           for e in self.extensions:
+-               e.extra_compile_args = ["-mstackrealign"]
++        xtra_compile_args = []
++
++        if self.compiler.compiler_type == "mingw32":
++            xtra_compile_args = [
++                       "-DMS_WIN32",
++                       "-mstackrealign"
++                       ] if is32bit else ["-DMS_WIN64"]
++
++        for e in self.extensions:
++            e.extra_compile_args = xtra_compile_args
++
+         build_ext.build_extensions(self)
+ 
++
+ packages = ["backports", "backports.lzma"]
+ prefix = sys.prefix
+ home = os.path.expanduser("~")

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -20,7 +20,7 @@ source:
 build:
   number: 2
   script:
-    - python setup.py build_ext --compiler=mingw32                    # [win and py2k]
+    - python setup.py build_ext --compiler=mingw32  # [win and py2k]
     - python setup.py install
 
 requirements:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -18,7 +18,7 @@ source:
     - PR_25.patch
 
 build:
-  number: 2
+  number: 3
   script:
     - python setup.py build_ext --compiler=mingw32  # [win and py2k]
     - python setup.py install

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -20,8 +20,7 @@ source:
 build:
   number: 2
   script:
-    - python setup.py build_ext --compiler=mingw32                    # [win32 and py2k]
-    - python setup.py build_ext --compiler=mingw32 --define=MS_WIN64  # [win64 and py2k]
+    - python setup.py build_ext --compiler=mingw32                    # [win and py2k]
     - python setup.py install
 
 requirements:


### PR DESCRIPTION
Refreshes the patch based on the accepted contents of PR ( https://github.com/peterjc/backports.lzma/pull/25 ). Drops one change to `.gitignore` as the `sdist` does not have this file. Otherwise this is a pretty accurate representation of the accepted changes. Simplifies the `script` used to build on Windows thanks to changes in the patch. Also bumps the build number to 3 in light of the changes made.